### PR TITLE
Add PDF export feature with sailboatdata.com attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,9 @@ python sailboat_compare.py "J/24" "J/80" "J/70"
 # JSON output
 python sailboat_compare.py "Catalina 30" "Hunter 33" --format json
 
+# PDF export
+python sailboat_compare.py "Catalina 30" "Hunter 33" --pdf comparison.pdf
+
 # Help
 python sailboat_compare.py --help
 ```
@@ -37,8 +40,16 @@ python sailboat_compare.py --help
 ### Without Nix
 
 ```bash
-# Install dependencies
-pip install requests beautifulsoup4 click rich lxml
+# Using pip
+pip install -r requirements.txt
+
+# Using conda
+conda env create -f environment.yml
+conda activate sailboat-compare
+
+# Using uv
+uv venv && source .venv/bin/activate
+uv pip install -r requirements.txt
 
 # Run tool
 python sailboat_compare.py "boat1" "boat2"
@@ -57,11 +68,18 @@ python sailboat_compare.py "boat1" "boat2"
 
 - **CLI Interface**: Built with Click framework
   - Accepts multiple boat names as arguments
-  - Supports table and JSON output formats
+  - Supports table, JSON, and PDF output formats
+  - Includes --pdf flag for PDF export
 
 - **Display Layer**: Uses Rich library for formatted output
   - Creates comparison tables with proper styling
   - Handles console output with colors and formatting
+  - Includes attribution to sailboatdata.com in all outputs
+
+- **PDF Export**: Uses ReportLab library for PDF generation
+  - Professional table formatting with headers and styling
+  - Automatic page orientation based on boat count
+  - Includes attribution header and generation timestamp
 
 ### URL Pattern
 
@@ -89,7 +107,7 @@ This fuzzy matching ensures users can find boats even when the exact naming conv
 ### Nix Flake Structure
 
 - Python 3.11 base environment
-- Dependencies: requests, beautifulsoup4, click, rich, lxml
+- Dependencies: requests, beautifulsoup4, click, rich, lxml, reportlab
 - Includes both development shell and package outputs
 - Compatible with direnv via `.envrc`
 
@@ -101,3 +119,5 @@ This fuzzy matching ensures users can find boats even when the exact naming conv
 - The scraper handles missing data gracefully with "-" placeholders
 - Unwanted UI elements are filtered from specifications (e.g., forum topics, navigation links)
 - Provides clear feedback when boats are found under alternative names
+- All outputs (CLI, JSON, PDF) include proper attribution to sailboatdata.com
+- PDF exports automatically adjust orientation based on the number of boats being compared

--- a/README.md
+++ b/README.md
@@ -8,14 +8,19 @@ A Python CLI tool for comparing sailboat specifications scraped from [sailboatda
 - 🔎 Intelligent boat name search with automatic variations (number-word conversions, spacing, etc.)
 - 📊 Compare multiple boats side-by-side
 - 🎨 Beautiful table output with Rich library
+- 📄 PDF export with professional formatting
 - 🔧 Nix flake for reproducible development environment
 - 📋 JSON export option
 - 🧹 Filtered output (excludes UI elements like forum topics)
+- ⚖️ Automatic attribution to sailboatdata.com in all outputs
 
 ## Prerequisites
 
-- [Nix](https://nixos.org/download.html) with flakes enabled
-- Or Python 3.11+ with pip
+Choose one of the following installation methods:
+- [Nix](https://nixos.org/download.html) with flakes enabled (recommended)
+- Python 3.11+ with pip
+- Conda/Mamba
+- uv (fast Python package installer)
 
 ## Installation & Setup
 
@@ -40,7 +45,22 @@ direnv allow
 ### Using pip
 
 ```bash
-pip install requests beautifulsoup4 click rich lxml
+pip install -r requirements.txt
+```
+
+### Using Conda
+
+```bash
+conda env create -f environment.yml
+conda activate sailboat-compare
+```
+
+### Using uv
+
+```bash
+uv venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+uv pip install -r requirements.txt
 ```
 
 ## Usage
@@ -61,6 +81,18 @@ Export to JSON:
 
 ```bash
 python sailboat_compare.py "Catalina 30" "Hunter 33" --format json
+```
+
+Export to PDF:
+
+```bash
+python sailboat_compare.py "Catalina 30" "Hunter 33" --pdf comparison.pdf
+```
+
+Combine table output and PDF export:
+
+```bash
+python sailboat_compare.py "J/24" "J/80" "J/70" --pdf boats.pdf
 ```
 
 Get help:
@@ -109,6 +141,7 @@ The flake provides a complete Python development environment with all dependenci
 - click (CLI framework)
 - rich (terminal formatting)
 - lxml (fast XML/HTML parser)
+- reportlab (PDF generation)
 
 ## Notes
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: sailboat-compare
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.11
+  - requests>=2.31.0
+  - beautifulsoup4>=4.12.0
+  - click>=8.1.0
+  - rich>=13.0.0
+  - lxml>=4.9.0
+  - reportlab>=4.0.0

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
           click
           rich
           lxml
+          reportlab
         ]);
       in
       {
@@ -46,6 +47,7 @@
             click
             rich
             lxml
+            reportlab
           ];
 
           meta = with pkgs.lib; {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests>=2.31.0
+beautifulsoup4>=4.12.0
+click>=8.1.0
+rich>=13.0.0
+lxml>=4.9.0
+reportlab>=4.0.0

--- a/sailboat_compare.py
+++ b/sailboat_compare.py
@@ -9,6 +9,7 @@ import sys
 import re
 from typing import Dict, List, Optional
 from urllib.parse import quote
+from datetime import datetime
 
 import click
 import requests
@@ -234,7 +235,7 @@ class SailboatScraper:
             return None
 
 
-def create_comparison_table(boats_data: List[Dict[str, str]]) -> Table:
+def create_comparison_table(boats_data: List[Dict[str, str]], show_attribution: bool = True) -> Table:
     """Create a rich table comparing boat specifications"""
 
     if not boats_data:
@@ -247,9 +248,13 @@ def create_comparison_table(boats_data: List[Dict[str, str]]) -> Table:
 
     all_specs = sorted(all_specs)
 
-    # Create table
+    # Create table with attribution in title if requested
+    title = "⛵ Sailboat Comparison"
+    if show_attribution:
+        title = "⛵ Sailboat Comparison\nData obtained from sailboatdata.com"
+
     table = Table(
-        title="⛵ Sailboat Comparison",
+        title=title,
         box=box.ROUNDED,
         show_header=True,
         header_style="bold cyan",
@@ -272,10 +277,146 @@ def create_comparison_table(boats_data: List[Dict[str, str]]) -> Table:
     return table
 
 
+def create_pdf(boats_data: List[Dict[str, str]], filename: str) -> bool:
+    """Create a PDF comparison of boat specifications"""
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.pagesizes import letter, landscape
+        from reportlab.platypus import SimpleDocTemplate, Table as PDFTable, TableStyle, Paragraph, Spacer
+        from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+        from reportlab.lib.units import inch
+        from reportlab.lib.enums import TA_CENTER
+    except ImportError:
+        console.print("[red]Error: reportlab is required for PDF export. Install it with: pip install reportlab[/red]")
+        return False
+
+    if not boats_data:
+        return False
+
+    # Get all unique specification keys
+    all_specs = set()
+    for boat in boats_data:
+        all_specs.update(k for k in boat.keys() if k not in ["name", "url"])
+    all_specs = sorted(all_specs)
+
+    # Create PDF
+    doc = SimpleDocTemplate(
+        filename,
+        pagesize=landscape(letter) if len(boats_data) > 2 else letter,
+        rightMargin=0.5*inch,
+        leftMargin=0.5*inch,
+        topMargin=0.75*inch,
+        bottomMargin=0.75*inch,
+    )
+
+    # Container for elements
+    elements = []
+    styles = getSampleStyleSheet()
+
+    # Add title
+    title_style = ParagraphStyle(
+        'CustomTitle',
+        parent=styles['Heading1'],
+        fontSize=16,
+        textColor=colors.HexColor('#1f77b4'),
+        spaceAfter=6,
+        alignment=TA_CENTER,
+    )
+    title = Paragraph("Sailboat Comparison", title_style)
+    elements.append(title)
+
+    # Add attribution
+    attribution_style = ParagraphStyle(
+        'Attribution',
+        parent=styles['Normal'],
+        fontSize=10,
+        textColor=colors.grey,
+        spaceAfter=12,
+        alignment=TA_CENTER,
+    )
+    attribution = Paragraph("Data obtained from sailboatdata.com", attribution_style)
+    elements.append(attribution)
+
+    # Add generation date
+    date_text = Paragraph(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}", attribution_style)
+    elements.append(date_text)
+    elements.append(Spacer(1, 0.2*inch))
+
+    # Prepare table data
+    table_data = []
+
+    # Header row
+    header = ["Specification"] + [boat["name"] for boat in boats_data]
+    table_data.append(header)
+
+    # Data rows
+    for spec in all_specs:
+        row = [spec]
+        for boat in boats_data:
+            value = boat.get(spec, "-")
+            row.append(value)
+        table_data.append(row)
+
+    # Create table
+    pdf_table = PDFTable(table_data, repeatRows=1)
+
+    # Style the table
+    table_style = TableStyle([
+        # Header styling
+        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#1f77b4')),
+        ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+        ('ALIGN', (0, 0), (-1, 0), 'CENTER'),
+        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+        ('FONTSIZE', (0, 0), (-1, 0), 10),
+        ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+
+        # Specification column styling
+        ('BACKGROUND', (0, 1), (0, -1), colors.HexColor('#f0f0f0')),
+        ('FONTNAME', (0, 1), (0, -1), 'Helvetica-Bold'),
+        ('FONTSIZE', (0, 1), (0, -1), 9),
+
+        # Data cells styling
+        ('FONTNAME', (1, 1), (-1, -1), 'Helvetica'),
+        ('FONTSIZE', (1, 1), (-1, -1), 8),
+        ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+        ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+
+        # Grid
+        ('GRID', (0, 0), (-1, -1), 1, colors.grey),
+        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.white, colors.HexColor('#f9f9f9')]),
+
+        # Padding
+        ('LEFTPADDING', (0, 0), (-1, -1), 6),
+        ('RIGHTPADDING', (0, 0), (-1, -1), 6),
+        ('TOPPADDING', (0, 0), (-1, -1), 4),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 4),
+    ])
+
+    pdf_table.setStyle(table_style)
+    elements.append(pdf_table)
+
+    # Add footer
+    elements.append(Spacer(1, 0.3*inch))
+    footer = Paragraph(
+        f"Visit <a href='https://sailboatdata.com'>sailboatdata.com</a> for more information",
+        attribution_style
+    )
+    elements.append(footer)
+
+    # Build PDF
+    try:
+        doc.build(elements)
+        return True
+    except Exception as e:
+        console.print(f"[red]Error creating PDF: {e}[/red]")
+        return False
+
+
 @click.command()
 @click.argument("boats", nargs=-1, required=True)
 @click.option("--format", "-f", type=click.Choice(["table", "json"]), default="table", help="Output format")
-def compare(boats: tuple, format: str):
+@click.option("--pdf", type=click.Path(), default=None, help="Export comparison to PDF file")
+def compare(boats: tuple, format: str, pdf: Optional[str]):
     """
     Compare specifications for multiple sailboats from sailboatdata.com
 
@@ -284,6 +425,7 @@ def compare(boats: tuple, format: str):
     Examples:
         sailboat_compare.py "Catalina 30" "Hunter 33"
         sailboat_compare.py "J/24" "J/80" "J/70" --format json
+        sailboat_compare.py "Catalina 30" "Hunter 33" --pdf comparison.pdf
     """
     if len(boats) < 2:
         console.print("[red]Error: Please provide at least two boat names to compare[/red]")
@@ -311,16 +453,31 @@ def compare(boats: tuple, format: str):
     if len(boats_data) < len(boats):
         console.print(f"[yellow]Warning: Only {len(boats_data)} of {len(boats)} boats found[/yellow]\n")
 
+    # Handle PDF export
+    if pdf:
+        console.print(f"[dim]Generating PDF: {pdf}...[/dim]")
+        if create_pdf(boats_data, pdf):
+            console.print(f"[green]✓ PDF created successfully: {pdf}[/green]")
+        else:
+            console.print("[red]✗ Failed to create PDF[/red]")
+            sys.exit(1)
+
+    # Handle output format
     if format == "json":
         import json
-        console.print_json(json.dumps(boats_data, indent=2))
+        # Add attribution to JSON output
+        output = {
+            "attribution": "Data obtained from sailboatdata.com",
+            "generated": datetime.now().isoformat(),
+            "boats": boats_data
+        }
+        console.print_json(json.dumps(output, indent=2))
     else:
-        table = create_comparison_table(boats_data)
+        table = create_comparison_table(boats_data, show_attribution=True)
         if table:
             console.print()
             console.print(table)
             console.print()
-            console.print("[dim]Data source: https://sailboatdata.com[/dim]")
         else:
             console.print("[red]Error: Could not create comparison table[/red]")
 


### PR DESCRIPTION
## Summary

This PR implements the PDF export feature requested in #3, along with proper attribution to sailboatdata.com in all output formats.

## Changes

### Features
- ✅ Added `--pdf` flag to export comparisons as PDF files
- ✅ Added "Data obtained from sailboatdata.com" attribution to:
  - CLI table output (in title)
  - JSON output (as top-level field)
  - PDF output (in header)
- ✅ Professional PDF formatting using ReportLab:
  - Automatic landscape/portrait orientation based on boat count
  - Styled tables with colored headers and alternating row backgrounds
  - Generation timestamp
  - Footer with link to sailboatdata.com

### Dependencies & Installation
- ✅ Added `reportlab` to Nix flake dependencies
- ✅ Created `requirements.txt` for pip users
- ✅ Created `environment.yml` for conda users
- ✅ Updated documentation with setup instructions for:
  - Nix (recommended)
  - pip
  - conda/mamba
  - uv

### Documentation
- ✅ Updated README.md with:
  - PDF export examples
  - Multiple installation methods
  - Feature list updates
- ✅ Updated CLAUDE.md with:
  - PDF export commands
  - Architecture details for PDF generation
  - Updated dependency lists

## Testing

Tested in Nix development environment:
- ✅ CLI table output shows attribution in title
- ✅ PDF generation works correctly
- ✅ PDF includes proper attribution header
- ✅ All dependencies load correctly via Nix

## Example Usage

```bash
# Generate PDF comparison
python sailboat_compare.py "Catalina 30" "Hunter 33" --pdf comparison.pdf

# Table output now shows attribution
python sailboat_compare.py "J/24" "J/80"

# JSON output includes attribution
python sailboat_compare.py "Catalina 30" "Hunter 33" --format json
```

## Acceptance Criteria from #3

- [x] CLI displays "Data obtained from sailboatdata.com" header
- [x] `--pdf` flag generates a properly formatted PDF file
- [x] PDF includes attribution header/footer
- [x] PDF maintains table structure and readability
- [x] PDF handles multiple boats (3+ comparisons)
- [x] Error handling for PDF generation failures
- [x] Update README with PDF export examples
- [x] Add PDF library to Nix flake dependencies

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)