### PR TITLE
Change PDF font to Times New Roman

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ python sailboat_compare.py "boat1" "boat2"
 
 - **PDF Export**: Uses ReportLab library for PDF generation
   - Professional table formatting with headers and styling
+  - Uses Times New Roman font family (Times-Roman, Times-Bold)
   - Automatic page orientation based on boat count
   - Includes attribution header and generation timestamp
 

--- a/sailboat_compare.py
+++ b/sailboat_compare.py
@@ -317,6 +317,7 @@ def create_pdf(boats_data: List[Dict[str, str]], filename: str) -> bool:
     title_style = ParagraphStyle(
         'CustomTitle',
         parent=styles['Heading1'],
+        fontName='Times-Bold',
         fontSize=16,
         textColor=colors.HexColor('#1f77b4'),
         spaceAfter=6,
@@ -329,6 +330,7 @@ def create_pdf(boats_data: List[Dict[str, str]], filename: str) -> bool:
     attribution_style = ParagraphStyle(
         'Attribution',
         parent=styles['Normal'],
+        fontName='Times-Roman',
         fontSize=10,
         textColor=colors.grey,
         spaceAfter=12,
@@ -366,17 +368,17 @@ def create_pdf(boats_data: List[Dict[str, str]], filename: str) -> bool:
         ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#1f77b4')),
         ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
         ('ALIGN', (0, 0), (-1, 0), 'CENTER'),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+        ('FONTNAME', (0, 0), (-1, 0), 'Times-Bold'),
         ('FONTSIZE', (0, 0), (-1, 0), 10),
         ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
 
         # Specification column styling
         ('BACKGROUND', (0, 1), (0, -1), colors.HexColor('#f0f0f0')),
-        ('FONTNAME', (0, 1), (0, -1), 'Helvetica-Bold'),
+        ('FONTNAME', (0, 1), (0, -1), 'Times-Bold'),
         ('FONTSIZE', (0, 1), (0, -1), 9),
 
         # Data cells styling
-        ('FONTNAME', (1, 1), (-1, -1), 'Helvetica'),
+        ('FONTNAME', (1, 1), (-1, -1), 'Times-Roman'),
         ('FONTSIZE', (1, 1), (-1, -1), 8),
         ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
         ('VALIGN', (0, 0), (-1, -1), 'TOP'),


### PR DESCRIPTION
## Summary
Changes the PDF export font from Helvetica to Times New Roman for a more professional and traditional appearance.

## Changes
- Updated table header font to Times-Bold (was Helvetica-Bold)
- Updated specification column font to Times-Bold (was Helvetica-Bold)
- Updated data cells font to Times-Roman (was Helvetica)
- Updated title paragraph style to use Times-Bold
- Updated attribution paragraph style to use Times-Roman
- Updated CLAUDE.md documentation to reflect font change

## Testing
- ✅ Generated test PDF with "Catalina 30" and "Hunter 33" comparison
- ✅ Verified PDF exports successfully without errors
- ✅ Confirmed all text elements use Times New Roman font family
- ✅ Layout and formatting remain intact

## Files Modified
- `sailboat_compare.py` - Updated ReportLab font configurations
- `CLAUDE.md` - Added documentation about Times New Roman usage

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)