### PR TITLE
Add black formatter hook for Python files

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,9 +17,32 @@
       "Bash(git pull:*)",
       "Bash(gh issue close:*)",
       "Bash(gh issue create:*)",
-      "Bash(gh issue reopen:*)"
+      "Bash(gh issue reopen:*)",
+      "Bash(black:*)"
     ],
     "deny": [],
     "ask": []
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit:*.py",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "black -t py313 \"${file_path}\""
+          }
+        ]
+      },
+      {
+        "matcher": "Write:*.py",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "black -t py313 \"${file_path}\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,20 @@ This fuzzy matching ensures users can find boats even when the exact naming conv
 ### Nix Flake Structure
 
 - Python 3.13 base environment
-- Dependencies: requests, beautifulsoup4, click, rich, lxml, reportlab
+- Dependencies: requests, beautifulsoup4, click, rich, lxml, reportlab, black
 - Includes both development shell and package outputs
 - Compatible with direnv via `.envrc`
+
+### Code Formatting
+
+The project uses Black formatter with Python 3.13 target for consistent code formatting:
+
+- **Automatic Formatting**: Claude Code is configured with PostToolUse hooks that automatically run `black -t py313` on all Python files after editing or writing
+- **Manual Formatting**: Run `black -t py313 <filename>.py` to format a specific file
+- **Hook Configuration**: Defined in `.claude/settings.local.json` under `hooks.PostToolUse`
+- **Permissions**: `Bash(black:*)` is pre-approved in the settings for automatic execution
+
+The hooks ensure all Python code maintains consistent formatting without manual intervention.
 
 ## Important Notes
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - rich>=13.0.0
   - lxml>=4.9.0
   - reportlab>=4.0.0
+  - black>=24.0.0

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
           rich
           lxml
           reportlab
+          black
         ]);
       in
       {
@@ -48,6 +49,7 @@
             rich
             lxml
             reportlab
+            black
           ];
 
           meta = with pkgs.lib; {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click>=8.1.0
 rich>=13.0.0
 lxml>=4.9.0
 reportlab>=4.0.0
+black>=24.0.0


### PR DESCRIPTION
## Summary

Adds automatic Python code formatting using black with Python 3.13 target via Claude Code PostToolUse hooks.

## Changes

- **Dependencies**: Added `black>=24.0.0` to:
  - requirements.txt
  - environment.yml
  - flake.nix

- **Hook Configuration**: Configured PostToolUse hooks in `.claude/settings.local.json`:
  - `Edit:*.py` - runs black after editing Python files
  - `Write:*.py` - runs black after writing Python files
  - Added `Bash(black:*)` to permissions allow list

- **Documentation**: Updated CLAUDE.md with new "Code Formatting" section explaining:
  - Automatic formatting via hooks
  - Manual formatting commands
  - Hook configuration details

## Testing

- ✅ Nix environment builds successfully with black dependency
- ✅ Tool functionality verified: Catalina 30 vs Hunter 33 comparison works correctly
- ✅ Hook configuration validated against schema
- ✅ Black formatter ready for automatic execution on Python file edits

## Benefits

- Ensures consistent Python code formatting across the project
- Maintains PEP 8 compliance automatically
- Reduces manual formatting effort for contributors

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)